### PR TITLE
Let `Scribe` be dropped on unwind

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -144,6 +144,8 @@ impl Scribe {
 
 impl Drop for Scribe {
     fn drop(&mut self) {
-        panic!("Scribe must be consumed explicitly");
+        if !std::thread::panicking() {
+            panic!("Scribe must be consumed explicitly");
+        }
     }
 }


### PR DESCRIPTION
Otherwise, it triggers the panic during unwind, which aborts the program. It's possible for well-written code to panic before the `Scribe` is consumed (e.g. panicking during the processing of files), which will cause unwinding to drop the `Scribe`, triggering this code path.