### PR TITLE
compile_inmemory: avoid Scribe guard panic

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,8 +45,8 @@ pub fn compile_result(
 /// Only the first compilation error is reported.
 pub fn compile_inmemory(source: &str) -> Result<BinaryNode, error::SourceError> {
     let arena = Arena::new();
-    let mut scribe = error::Scribe::new(false);
     let dts = parse::parse_typed(source, &arena)?;
+    let mut scribe = error::Scribe::new(false);
     let (tree, node_labels) = merge::merge(dts, &mut scribe);
     let r = eval::eval(tree, node_labels, &fs::DummyLoader, &mut scribe);
     scribe.collect().map(|_| r)


### PR DESCRIPTION
Create the scribe after calling `parse::parse_typed()?` so that an early return doesn't leave the Scribe unconsumed.