### PR TITLE
Support parsing <a.b>-style float literals

### DIFF
--- a/src/dts.pest
+++ b/src/dts.pest
@@ -129,7 +129,7 @@ LabelOrCell = { Label | Cell }
 OpenCells = { "<" }
 CloseCells = { ">" }
 
-Cell = { NodeReference | PropertyReference | ParenExpr | IntLiteral }
+Cell = { NodeReference | PropertyReference | ParenExpr | FloatLiteral | IntLiteral }
 
 ParenExpr = { OpenParen ~ Expr ~ CloseParen }
 Expr = { TernaryPrec }
@@ -184,6 +184,10 @@ LessThan = { "<" }
 GreaterThan = { ">" }
 Equal = { "==" }
 NotEqual = { "!=" }
+
+// DIFF: dtc has no floating-point support.  Cells accept <a.b>-style literals,
+//       encoded as IEEE 754 (binary32 by default, binary64 with /bits/ 64).
+FloatLiteral = @{ "-"? ~ ('0'..'9')+ ~ "." ~ ('0'..'9')+ ~ (^"e" ~ ("+" | "-")? ~ ('0'..'9')+)? }
 
 IntLiteral = ${ CharLiteral | NumericLiteral }
 

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -395,6 +395,24 @@ fn evaluate_propvalue(
                                 }
                             }
                         }
+                        Cell::FloatLiteral(lit) => {
+                            let v: f64 = lit
+                                .str()
+                                .parse()
+                                .map_err(|_| lit.err("bad float literal"))?;
+                            // IEEE 754 bit patterns must not go through the
+                            // sign-extension check below.
+                            match bits {
+                                32 => r.extend((v as f32).to_be_bytes()),
+                                64 => r.extend(v.to_be_bytes()),
+                                _ => {
+                                    return Err(
+                                        lit.err("float literals need /bits/ == 32 or 64")
+                                    );
+                                }
+                            }
+                            continue;
+                        }
                         Cell::ParenExpr(expr) => expr.eval(lookup_property)?,
                         Cell::IntLiteral(lit) => lit.eval(lookup_property)?,
                     };
@@ -762,6 +780,7 @@ fn test_eval() {
     for source in [
         include_str!("testdata/charlit.dts"),
         include_str!("testdata/expr.dts"),
+        include_str!("testdata/float.dts"),
         include_str!("testdata/phandle.dts"),
         #[cfg(feature = "wrapping-arithmetic")]
         include_str!("testdata/random_expressions.dts"),

--- a/src/testdata/float.dts
+++ b/src/testdata/float.dts
@@ -1,0 +1,14 @@
+/dts-v1/;
+
+/ {
+    check {
+        f32_simple   = <1.23 0x3f9d70a4>;
+        f32_zero     = <0.0 0x00000000>;
+        f32_negative = <-0.5 0xbf000000>;
+        f32_exponent = <2.5e3 0x451c4000>;
+        f32_exp_neg  = <1.5E-1 0x3e19999a>;
+        f32_mixed    = <1 2.0 1 0x40000000>;
+        f64_simple   = /bits/ 64 <1.23 0x3ff3ae147ae147ae>;
+        f64_negative = /bits/ 64 <-0.5 0xbfe0000000000000>;
+    };
+};


### PR DESCRIPTION
Extend the grammar to support floating point numbers. The new rule handles '-?digits.digits' with an optional 'e+/-N' exponent.

The numbers are encoded as IEEE 754 — binary32 by default, or as binary64 with `/bits/ 64`.